### PR TITLE
Added sdivACbyDE and reduced icos and isin range to prevent sign overflow

### DIFF
--- a/src/00/jumptable.config
+++ b/src/00/jumptable.config
@@ -130,7 +130,7 @@
     sub16from32
     divHLbyC
     divACbyDE
-    sdivACbyDE
+    sDivACbyDE
     smin
     smax
     isin

--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -295,7 +295,7 @@ divACbyDE:
 ;;  HL: remainder
 ;; Notes:
 ;;  B is destroyed
-sdivACbyDE:
+sDivACbyDE:
     xor d
     push af
         xor d


### PR DESCRIPTION
Specifically when using fx3dlib : 64 + 64 = 128 = -128 with A. So icos and isin are now in [-63, 63].
