### PR TITLE
Documentation: add "unimplemented" note to two functions

### DIFF
--- a/src/01/text.asm
+++ b/src/01/text.asm
@@ -526,6 +526,8 @@ drawHexHL:
 ;;  HL: Value
 ;; Outputs:
 ;;  D, E: Advanced to position of next character
+;; Notes:
+;;  This is unimplemented.
 drawDecHL:
     ; TODO
     ret

--- a/src/02/time.asm
+++ b/src/02/time.asm
@@ -275,6 +275,8 @@ _:
 ;; Outputs:
 ;;   HL: Lower word of tick value
 ;;   DE: Upper word of tick value
+;; Notes:
+;;  This is unimplemented.
 convertTimeToTicks:
     ; TODO
     ret


### PR DESCRIPTION
Added notes that `drawDecHL` and `convertTimeToTicks` are still unimplemented, to prevent developer confusion.
