### PR TITLE
Add clockSupported function

### DIFF
--- a/src/02/jumptable.config
+++ b/src/02/jumptable.config
@@ -37,3 +37,6 @@
     rectXOR
     rectAND
     drawVLineAND
+
+# Time [continued]
+    clockSupported

--- a/src/02/time.asm
+++ b/src/02/time.asm
@@ -1,3 +1,17 @@
+;; clockSupported [Time]
+;;   Returns whether the clock is supported.
+;; Outputs:
+;;   A: preserved on success; error code on failure
+;;   Z: set when the clock is supported; reset otherwise
+clockSupported:
+#ifdef CLOCK
+    cp a ; set Z
+#else
+    ld a, errUnsupported
+    or 1 ; reset Z
+#endif
+    ret
+
 ;; setClock [Time]
 ;;   Sets the internal clock.
 ;; Inputs:


### PR DESCRIPTION
This is only a very simple function, but I'd like to know whether my code style is correct for the kernel :smiley:

By the way, I put `clockSupported` at the end of the jump table to avoid corelib from doing calls to the wrong functions. Is that the correct way to do it?