### PR TITLE
Optimized add16to32, mul16By16

### DIFF
--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -5,7 +5,7 @@
 cpHLDE:
     or a
     sbc hl, de
-    add hl,de
+    add hl, de
     ret
 ;; cpHLBC [Maths]
 ;;  Compares HL to BC.
@@ -14,7 +14,7 @@ cpHLDE:
 cpHLBC:
     or a
     sbc hl, bc
-    add hl,bc
+    add hl, bc
     ret
 ;; cpBCDE [Maths]
 ;;  Compares DE to BC.
@@ -128,41 +128,41 @@ mul16By8:
 ;; Outputs:
 ;;  DEHL: Product of DE and BC.
 mul16By16:
-    ld hl,0
-    ld a,b
-    ld b,h
+    ld hl, 0
+    ld a, b
+    ld b, h
     or a
-                rla \ jr nc,$+5 \ ld h,d \ ld l,e
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
-    ld b,a
+                rla \ jr nc, $+5 \ ld h, d \ ld l, e
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+    ld b, a
     push hl
-    ld hl,0
-    ld a,c
-    ld c,h
+    ld hl, 0
+    ld a, c
+    ld c, h
     or a
-                rla \ jr nc,$+5 \ ld h,d \ ld l,e
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
-    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
-    ld d,b
+                rla \ jr nc, $+5 \ ld h, d \ ld l, e
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+    ld d, b
     pop bc
-    ld e,a
-    ld a,c
-    add a,h
-    ld h,a
-    ld a,e
-    adc a,b
-    ld e,a
+    ld e, a
+    ld a, c
+    add a, h
+    ld h, a
+    ld a, e
+    adc a, b
+    ld e, a
     ret nc
     inc d
     ret
@@ -214,16 +214,16 @@ div32By16:
     add ix, ix
     rl c
     rla
-    adc hl,hl
+    adc hl, hl
     jr  c, .overflow
-    sbc hl,de
+    sbc hl, de
     jr  nc, .setBit
-    add hl,de
+    add hl, de
     djnz .loop
     ret
 .overflow:
     or a
-    sbc hl,de
+    sbc hl, de
 .setBit:
     inc ixl
     djnz .loop
@@ -313,7 +313,7 @@ _:  push hl \ pop ix
 ;; add16To32 [Maths]
 ;;  Performs `ACIX = ACIX + DE`
 add16to32:
-    add ix,de
+    add ix, de
     ret nc
     inc c
     ret nc

--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -127,42 +127,49 @@ mul16By8:
 ;;  BC: Multiplicand
 ;; Outputs:
 ;;  DEHL: Product of DE and BC.
+;;Min: 518cc
+;;Max: 669cc
+;;Avg: 589.53125cc
+;;125 bytes
 mul16By16:
-    ld hl, 0
-
-    sla e
-    rl d
-    jr nc, $ + 4
-    ld h, b
-    ld l, c
-
-.macro mul16By16Iter
-    add hl, hl
-    rl e
-    rl d
-    jr nc, $ + 6
-    add hl, bc
-    jr nc, $ + 3
-    inc de
-.endmacro
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-    mul16By16Iter
-.undefine mul16By16Iter
+    ld hl,0
+    ld a,b
+    ld b,h
+    or a
+                rla \ jr nc,$+5 \ ld h,d \ ld l,e
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,b
+    ld b,a
+    push hl
+    ld hl,0
+    ld a,c
+    ld c,h
+    or a
+                rla \ jr nc,$+5 \ ld h,d \ ld l,e
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
+    add hl,hl \ rla \ jr nc,$+4 \ add hl,de \ adc a,c
+    ld d,b
+    pop bc
+    ld e,a
+    ld a,c
+    add a,h
+    ld h,a
+    ld a,e
+    adc a,b
+    ld e,a
+    ret nc
+    inc d
     ret
-
 ;; mul32By8 [Maths]
 ;;  Performs an unsigned multiplication of DEHL and A.
 ;; Outputs:
@@ -309,21 +316,16 @@ _:  push hl \ pop ix
 
 ;; add16To32 [Maths]
 ;;  Performs `ACIX = ACIX + DE`
+;;Min: 26cc
+;;Max: 43cc
+;;Avg: 30.515625cc
+;;7 bytes
 add16to32:
-    push hl
-        push de
-            push ix \ pop hl
-            push de
-                ld d, a
-                ld e, c
-            pop bc
-            add hl, bc
-            jr nc, _
-            inc de
-_:          push hl \ pop ix
-            ld a, d \ ld c, e
-        pop de
-    pop hl
+    add ix,de
+    ret nc
+    inc c
+    ret nc
+    inc a
     ret
 
 ;; divHLByC [Maths]

--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -128,6 +128,8 @@ mul16By8:
 ;; Outputs:
 ;;  DEHL: Product of DE and BC.
 mul16By16:
+    push bc
+    push af
     ld hl, 0
     ld a, b
     ld b, h
@@ -163,6 +165,9 @@ mul16By16:
     ld a, e
     adc a, b
     ld e, a
+    pop bc
+    ld a,b
+    pop bc
     ret nc
     inc d
     ret

--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -127,10 +127,6 @@ mul16By8:
 ;;  BC: Multiplicand
 ;; Outputs:
 ;;  DEHL: Product of DE and BC.
-;;Min: 518cc
-;;Max: 669cc
-;;Avg: 589.53125cc
-;;125 bytes
 mul16By16:
     ld hl,0
     ld a,b
@@ -316,10 +312,6 @@ _:  push hl \ pop ix
 
 ;; add16To32 [Maths]
 ;;  Performs `ACIX = ACIX + DE`
-;;Min: 26cc
-;;Max: 43cc
-;;Avg: 30.515625cc
-;;7 bytes
 add16to32:
     add ix,de
     ret nc

--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -129,43 +129,43 @@ mul16By8:
 ;;  DEHL: Product of DE and BC.
 mul16By16:
     push bc
-    push af
-    ld hl, 0
-    ld a, b
-    ld b, h
-    or a
-                rla \ jr nc, $+5 \ ld h, d \ ld l, e
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
-    ld b, a
-    push hl
-    ld hl, 0
-    ld a, c
-    ld c, h
-    or a
-                rla \ jr nc, $+5 \ ld h, d \ ld l, e
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
-    add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
-    ld d, b
-    pop bc
-    ld e, a
-    ld a, c
-    add a, h
-    ld h, a
-    ld a, e
-    adc a, b
-    ld e, a
-    pop bc
+        push af
+            ld hl, 0
+            ld a, b
+            ld b, h
+            or a
+                        rla \ jr nc, $+5 \ ld h, d \ ld l, e
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, b
+            ld b, a
+            push hl
+            ld hl, 0
+            ld a, c
+            ld c, h
+            or a
+                        rla \ jr nc, $+5 \ ld h, d \ ld l, e
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+            add hl, hl \ rla \ jr nc, $+4 \ add hl, de \ adc a, c
+            ld d, b
+            pop bc
+            ld e, a
+            ld a, c
+            add a, h
+            ld h, a
+            ld a, e
+            adc a, b
+            ld e, a
+        pop bc
     ld a,b
     pop bc
     ret nc


### PR DESCRIPTION
My coding style is different, so please verify that my additions are okay.
These are win-win optimizations. They are smaller and faster in all cases.

add16to32 is now 7 bytes, avg. 30.515625cc, versus 21 bytes, avg 164.5cc
mul16By16 is now 125 bytes, avg.589.53125cc, versus 177 bytes, avg 763.5cc

With add16to32, note that add ix,de is a valid documented instruction, which seems to be a key part in optimizing that code.