### PR TITLE
Updated math routines, rand routines.

### DIFF
--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -320,8 +320,7 @@ add16to32:
     add ix, de
     ret nc
     inc c
-    ret nc
-    inc a
+    adc a,0
     ret
 
 ;; divHLByC [Maths]

--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -295,22 +295,21 @@ div8By8:
 ;;  Performs `ACIX = ACIX - DE`
 sub16from32:
     push hl
-    push de
     push bc
-        push ix \ pop hl
-        push de
-            ld d, a
-            ld e, c
-        pop bc
-
-        or a
+        ld h, a
+        ld l, c
+        xor a
+        ld b, a
+        ld c, a
+        push ix
+            ex (sp), hl
+            sbc hl, de
+            ex (sp), hl
+        pop ix
         sbc hl, bc
-        jr nc, _
-        dec de
-_:  push hl \ pop ix
-    ld a, d \ ld c, e
+        ld a, h
     pop bc
-    pop de
+    ld c, l
     pop hl
     ret
 
@@ -319,8 +318,10 @@ _:  push hl \ pop ix
 add16to32:
     add ix, de
     ret nc
+    or a
     inc c
-    adc a,0
+    ret z
+    add a, 1
     ret
 
 ;; divHLByC [Maths]

--- a/src/00/math.asm
+++ b/src/00/math.asm
@@ -165,11 +165,10 @@ mul16By16:
             ld a, e
             adc a, b
             ld e, a
-        pop bc
-    ld a,b
+            jr nc, $ + 3
+            inc d
+        pop af
     pop bc
-    ret nc
-    inc d
     ret
 ;; mul32By8 [Maths]
 ;;  Performs an unsigned multiplication of DEHL and A.

--- a/src/00/random.asm
+++ b/src/00/random.asm
@@ -9,10 +9,10 @@ initRandom:
         ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
         ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
         ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
+        ld a, r \ or (hl) \ ld l, a  \ ld (de), a \ inc de  ;we use two ors to ensure this part of the seed is non-zero.
         ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
         ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
-        ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
-        ld a, r \ add a, (hl) \ ld (de), a
+        ld a, r \ or (hl) \ ld (de), a
     pop af
     pop de
     pop hl

--- a/src/00/random.asm
+++ b/src/00/random.asm
@@ -1,58 +1,57 @@
 initRandom:
     push hl
+    push de
     push af
-        setBankA(0x04) ; filesystem, probably pretty unpredictable
-        ld hl, 0x4000
-        ld a, r \ rrca \ xor (hl) \ inc hl \ ld (random_seed), a
-        ld a, r \ rrca \ xor (hl) \ inc hl \ ld (random_seed + 1), a
-        ld a, r \ rrca \ xor (hl) \ inc hl \ ld (random_seed + 2), a
-        ld a, r \ rrca \ xor (hl) \ inc hl \ ld (random_seed + 3), a
-        ld a, r \ rrca \ xor (hl) \ inc hl \ ld (random_seed + 4), a
-        ld a, r \ rrca \ xor (hl) \ inc hl \ ld (random_seed + 5), a
-        ld a, r \ rrca \ xor (hl) \ inc hl \ ld (random_seed + 6), a
-        ld a, r \ rrca \ xor (hl) \ inc hl \ ld (random_seed + 7), a
+        setBankA(0x04) ; filesystem,  probably pretty unpredictable
+        ld hl, 0x4010
+        ld de, random_seed
+        ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
+        ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
+        ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
+        ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
+        ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
+        ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
+        ld a, r \ add a, (hl) \ ld l, a  \ ld (de), a \ inc de
+        ld a, r \ add a, (hl) \ ld (de), a
     pop af
+    pop de
     pop hl
     ret
-
+    
 ;; getRandom [Miscellaneous]
 ;;  Gets an 8-bit random number.
 ;; Outputs:
 ;;  A: Random number (0-255)
 ;; Notes:
 ;;  This is not cryptographically random.
-getRandom:
     push hl
     push de
     push bc
-        ld hl, random_seed+4
-        ld e, (hl)
-        inc hl
-        ld d, (hl)
-        inc hl
-        ld c, (hl)
-        inc hl
-        ld a, (hl)
-        ld b, a
-        rl e \ rl d
-        rl c \ rla
-        rl e \ rl d
-        rl c \ rla
-        rl e \ rl d
-        rl c \ rla
-        ld h, a
-        rl e \ rl d
-        rl c \ rla
-        xor b
-        rl e \ rl d
-        xor h
-        xor c
-        xor d
-        ld hl, random_seed+6
-        ld de, random_seed+7
-        ld bc, 7
-        lddr
-        ld (de), a
+        ld hl, (random_seed)
+        ld de, (random_seed+2)
+        ld b, h
+        ld c, l
+        add hl, hl \ rl e \ rl d
+        add hl, hl \ rl e \ rl d
+        inc l
+        add hl, bc
+        ld (random_seed), hl
+        ld hl, (random_seed+2)
+        adc hl, de
+        ld (random_seed+2), hl
+        ex de, hl
+        ld hl, (random_seed+4)
+        ld de, (random_seed+6)
+        ld bc, 54321
+        add hl, hl \ rl c \ rl b
+        ld (random_seed+6), bc
+        sbc a, a
+        and %11000101
+        xor l
+        ld l, a
+        ld (random_seed+4), hl
+        ld a, d
+        add a, b
     pop bc
     pop de
     pop hl


### PR DESCRIPTION
I modified the add16to32 and sub16from32 routines so that they are still smaller and faster than the originals, but also reliably affect the carry flag on overflows.

As well, I have some proposed changes to the random routines.
initRandom is similar to what it was before, but I opted to use add instead of xor as the properties of adding are better suited to random number generation. As before, it isn't amazing, but it works.

getRandom now uses a routine that was independently verified as "good" by CACert Labs. It still uses 8 bytes of state, as in the original, and has a similar period size.

getRandom is +7 bytes, -70cc
initRandom is -9 bytes -11cc, so we have a net decrease in size.